### PR TITLE
make appspec_filename a var

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module "my_app" {
 | codedeploy_termination_wait_time | number | the number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment | 15 |
 | codedeploy_test_listener_port | number | The port for a codedeploy test listener. If provided CodeDeploy will use this port for test traffic on the new replacement set during the blue-green deployment process before shifting production traffic to the replacement set | null |
 | codedeploy_lifecycle_hooks | [object](#codedeploy_lifecycle_hooks) | Define Lambda Functions for each CodeDeploy [lifecycle event hooks](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html). Use the Lambda function names as the values. Use null if you don't want to invoke a lambda function at that specific hook. Or set this variable to null to not have any lifecycle hooks invoked | `null` |
-| appspec_filename | string | Filename (including path) to use when outputing appspec json. | ${path.cwd}/appspec.json |
+| appspec_filename | string | Filename (including path) to use when outputing appspec json. | `appspec.json` in the current working directory (i.e. where you ran `terraform apply`) |
 | role_permissions_boundary_arn | string | ARN of the IAM Role permissions boundary to place on each IAM role created | |
 | target_group_deregistration_delay | number | Deregistration delay in seconds for ALB target groups | 60 |
 | hosted_zone | [object](#hosted_zone) | Hosted Zone object to redirect to ALB. (Can pass in the aws_hosted_zone object). A and AAAA records created in this hosted zone | |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ customized solution you may need to use this code more as a pattern or guideline
 ## Usage
 ```hcl
 module "my_app" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.1"
   app_name       = "example-api"
   container_port = 8000
   primary_container_definition = {
@@ -95,6 +95,7 @@ module "my_app" {
 | codedeploy_termination_wait_time | number | the number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment | 15 |
 | codedeploy_test_listener_port | number | The port for a codedeploy test listener. If provided CodeDeploy will use this port for test traffic on the new replacement set during the blue-green deployment process before shifting production traffic to the replacement set | null |
 | codedeploy_lifecycle_hooks | [object](#codedeploy_lifecycle_hooks) | Define Lambda Functions for each CodeDeploy [lifecycle event hooks](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html). Use the Lambda function names as the values. Use null if you don't want to invoke a lambda function at that specific hook. Or set this variable to null to not have any lifecycle hooks invoked | `null` |
+| appspec_filename | string | Filename (including path) to use when outputing appspec json. | ${path.cwd}/appspec.json |
 | role_permissions_boundary_arn | string | ARN of the IAM Role permissions boundary to place on each IAM role created | |
 | target_group_deregistration_delay | number | Deregistration delay in seconds for ALB target groups | 60 |
 | hosted_zone | [object](#hosted_zone) | Hosted Zone object to redirect to ALB. (Can pass in the aws_hosted_zone object). A and AAAA records created in this hosted zone | |

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -11,7 +11,7 @@ module "acs" {
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.1"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/main.tf
+++ b/main.tf
@@ -565,7 +565,7 @@ resource "aws_cloudwatch_metric_alarm" "down" {
 
 # ==================== AppSpec file ====================
 resource "local_file" "appspec_json" {
-  filename = "${path.cwd}/appspec.json"
+  filename = var.appspec_filename
   content = jsonencode({
     version = 1
     Resources = [{

--- a/main.tf
+++ b/main.tf
@@ -565,7 +565,7 @@ resource "aws_cloudwatch_metric_alarm" "down" {
 
 # ==================== AppSpec file ====================
 resource "local_file" "appspec_json" {
-  filename = var.appspec_filename
+  filename = var.appspec_filename != null ? var.apspec_filename : "${path.cwd}/appspec.json"
   content = jsonencode({
     version = 1
     Resources = [{

--- a/main.tf
+++ b/main.tf
@@ -565,7 +565,7 @@ resource "aws_cloudwatch_metric_alarm" "down" {
 
 # ==================== AppSpec file ====================
 resource "local_file" "appspec_json" {
-  filename = var.appspec_filename != null ? var.apspec_filename : "${path.cwd}/appspec.json"
+  filename = var.appspec_filename != null ? var.appspec_filename : "${path.cwd}/appspec.json"
   content = jsonencode({
     version = 1
     Resources = [{

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,11 @@ variable "codedeploy_lifecycle_hooks" {
   description = "Define Lambda Functions for CodeDeploy lifecycle event hooks. Or set this variable to null to not have any lifecycle hooks invoked. Defaults to null"
   default     = null
 }
+variable "appspec_filename" {
+  type = string
+  description = "Filename (including path) to use when outputing appspec json."
+  default = "${path.cwd}/appspec.json"
+}
 variable "role_permissions_boundary_arn" {
   type        = string
   description = "ARN of the IAM Role permissions boundary to place on each IAM role created."

--- a/variables.tf
+++ b/variables.tf
@@ -134,7 +134,7 @@ variable "codedeploy_lifecycle_hooks" {
 variable "appspec_filename" {
   type        = string
   description = "Filename (including path) to use when outputing appspec json."
-  default     = "${path.cwd}/appspec.json"
+  default     = null
 }
 variable "role_permissions_boundary_arn" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -132,9 +132,9 @@ variable "codedeploy_lifecycle_hooks" {
   default     = null
 }
 variable "appspec_filename" {
-  type = string
+  type        = string
   description = "Filename (including path) to use when outputing appspec json."
-  default = "${path.cwd}/appspec.json"
+  default     = "${path.cwd}/appspec.json"
 }
 variable "role_permissions_boundary_arn" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,7 @@ variable "codedeploy_lifecycle_hooks" {
 }
 variable "appspec_filename" {
   type        = string
-  description = "Filename (including path) to use when outputing appspec json."
+  description = "`appspec.json` in the current working directory (i.e. where you ran `terraform apply`)"
   default     = null
 }
 variable "role_permissions_boundary_arn" {


### PR DESCRIPTION
I have a project that deploys two instances of this module (yes, in the same project). The second appspec file is overwriting the first.

This change allows the developer to specify a filename.