### PR TITLE
Output task policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ customized solution you may need to use this code more as a pattern or guideline
 ## Usage
 ```hcl
 module "my_app" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.3"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.4"
   app_name       = "example-api"
   container_port = 8000
   primary_container_definition = {
@@ -185,6 +185,8 @@ For instance with the [above example](#usage) the logs could be found in the Clo
 | dns_record | [object](https://www.terraform.io/docs/providers/aws/r/route53_record.html#attributes-reference) | The DNS A-record mapped to the ALB | 
 | autoscaling_step_up_policy | [object](https://www.terraform.io/docs/providers/aws/r/autoscaling_policy.html#attributes-reference) | Autoscaling policy to step up |
 | autoscaling_step_down_policy | [object](https://www.terraform.io/docs/providers/aws/r/autoscaling_policy.html#attributes-reference) | Autoscaling policy to step down |
+| task_role | [object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#attributes-reference) | IAM role created for the tasks. |
+| task_execution_role | [object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#attributes-reference) | IAM role created for the execution of tasks. |
 
 #### appspec
 This module also creates a JSON file in the project directory: `appspec.json` used to initiate a CodeDeploy Deployment.

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -100,3 +100,11 @@ output "autoscaling_step_up_policy" {
 output "autoscaling_step_down_policy" {
   value = module.fargate_api.autoscaling_step_down_policy
 }
+
+output "task_role" {
+  value = module.fargate_api.task_role
+}
+
+output "task_execution_role" {
+  value = module.fargate_api.task_execution_role
+}

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -11,7 +11,7 @@ module "acs" {
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.3"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.4"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,3 +45,11 @@ output "autoscaling_step_up_policy" {
 output "autoscaling_step_down_policy" {
   value = var.autoscaling_config != null ? aws_appautoscaling_policy.down : null
 }
+
+output "task_role" {
+  value = aws_iam_role.task_role
+}
+
+output "task_execution_role" {
+  value = aws_iam_role.task_execution_role
+}


### PR DESCRIPTION
Adding these outputs give users easier access to task policies to they can add more access if needed. Example: the Persons API uses custom CloudWatch metrics for scaling and the task needed access to put those custom metrics.
