### PR TITLE
Add ability to log ALB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ customized solution you may need to use this code more as a pattern or guideline
 ## Usage
 ```hcl
 module "my_app" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.0.4"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.1.0"
   app_name       = "example-api"
   container_port = 8000
   primary_container_definition = {
@@ -104,6 +104,8 @@ module "my_app" {
 | autoscaling_config | [object](#autoscaling_config) | Configuration for default autoscaling policies and alarms. Set to `null` if you want to set up your own autoscaling policies and alarms.  | |
 | log_retention_in_days | number | CloudWatch log group retention in days | 120 |
 | tags | map(string) | A map of AWS Tags to attach to each resource created | {} |
+| lb_logging_enabled | bool | Option to enable logging of load balancer requests. | false |
+| lb_logging_bucket_name | string | Required if `lb_logging_enabled` is true. A bucket to store the logs in with an a [load balancer access policy](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy) attached. | |
 
 #### container_definition
 Object with following attributes to define the docker container(s) your fargate needs to run.

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 module "acs" {
-  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v3.0.0"
+  source = "github.com/byu-oit/terraform-aws-acs-info?ref=v3.1.0"
 }
 
 module "fargate_api" {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -7,6 +7,8 @@ module "acs" {
   source = "github.com/byu-oit/terraform-aws-acs-info?ref=v3.1.0"
 }
 
+data "aws_caller_identity" "current" {}
+
 //resource "aws_ecs_cluster" "existing" {
 //  name = "fake-example-cluster"
 //}
@@ -46,12 +48,73 @@ module "fargate_api" {
   vpc_id                        = module.acs.vpc.id
   codedeploy_service_role_arn   = module.acs.power_builder_role.arn
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
+  lb_logging_enabled            = true
+  lb_logging_bucket_name        = aws_s3_bucket.lb_logs.bucket
 
   tags = {
     env              = "dev"
     data-sensitivity = "internal"
     repo             = "https://github.com/byu-oit/terraform-aws-fargate-api"
   }
+}
+
+resource "aws_s3_bucket" "lb_logs" {
+  bucket        = "example-api-access-logs"
+  force_destroy = true
+
+  lifecycle_rule {
+    enabled                                = true
+    abort_incomplete_multipart_upload_days = 10
+    id                                     = "AutoAbortFailedMultipartUpload"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "lb_logs_bucket" {
+  bucket = aws_s3_bucket.lb_logs.id
+  policy = <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::797873946194:root"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.lb_logs.bucket}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "delivery.logs.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.lb_logs.bucket}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": "bucket-owner-full-control"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "delivery.logs.amazonaws.com"
+      },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.lb_logs.bucket}"
+    }
+  ]
+}
+JSON
 }
 
 output "url" {

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,13 @@ resource "aws_alb" "alb" {
   subnets         = var.public_subnet_ids
   security_groups = [aws_security_group.alb-sg.id]
   tags            = var.tags
+
+  access_logs {
+    bucket  = var.lb_logging_bucket_name
+    enabled = var.lb_logging_enabled
+  }
 }
+
 resource "aws_security_group" "alb-sg" {
   name        = "${local.alb_name}-sg"
   description = "Controls access to the ${local.alb_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,13 @@ variable "tags" {
   description = "A map of AWS Tags to attach to each resource created"
   default     = {}
 }
+variable "lb_logging_enabled" {
+  type        = bool
+  description = "Option to enable logging of load balancer requests."
+  default     = false
+}
+variable "lb_logging_bucket_name" {
+  type        = string
+  description = "Bucket for ALB access logs."
+  default     = ""
+}


### PR DESCRIPTION
I needed this when developing the Persons API. A bucket needs to be created with a polciy that includes an ELB account number based on the region, working account number, and bucket name. So I figured it would be easier if the user provides that themselves rather than do it in the module.
