### PR TITLE
Allow overwrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ module "my_app" {
 | target_group_deregistration_delay | number | Deregistration delay in seconds for ALB target groups | 60 |
 | target_group_sticky_sessions | boolean | Enables sticky sessions on the ALB target groups | false |
 | site_url | string | The URL for the site. | Concatenates app_name with hosted_zone_name. |
+| allow_overwrite | bool | Allow creation of Route53 records in Terraform to overwrite an existing record, if any. | false |
 | hosted_zone | [object](#hosted_zone) | Hosted Zone object to redirect to ALB. (Can pass in the aws_hosted_zone object). A and AAAA records created in this hosted zone | |
 | https_certificate_arn | string | ARN of the HTTPS certificate of the hosted zone/domain | |
 | autoscaling_config | [object](#autoscaling_config) | Configuration for default autoscaling policies and alarms. Set to `null` if you want to set up your own autoscaling policies and alarms.  | |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ customized solution you may need to use this code more as a pattern or guideline
 ## Usage
 ```hcl
 module "my_app" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.2.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.2.2"
   app_name       = "example-api"
   container_port = 8000
   primary_container_definition = {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -14,7 +14,7 @@ data "aws_elb_service_account" "main" {}
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.2.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.2.2"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -11,7 +11,7 @@ module "acs" {
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.2.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.2.2"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/main.tf
+++ b/main.tf
@@ -254,9 +254,9 @@ resource "aws_alb_listener" "test_listener" {
 
 # ==================== Route53 ====================
 resource "aws_route53_record" "a_record" {
-  name    = local.app_domain_url
-  type    = "A"
-  zone_id = var.hosted_zone.id
+  name            = local.app_domain_url
+  type            = "A"
+  zone_id         = var.hosted_zone.id
   allow_overwrite = var.overwrite_records
   alias {
     evaluate_target_health = true
@@ -265,9 +265,9 @@ resource "aws_route53_record" "a_record" {
   }
 }
 resource "aws_route53_record" "aaaa_record" {
-  name    = local.app_domain_url
-  type    = "AAAA"
-  zone_id = var.hosted_zone.id
+  name            = local.app_domain_url
+  type            = "AAAA"
+  zone_id         = var.hosted_zone.id
   allow_overwrite = var.overwrite_records
   alias {
     evaluate_target_health = true

--- a/main.tf
+++ b/main.tf
@@ -257,6 +257,7 @@ resource "aws_route53_record" "a_record" {
   name    = local.app_domain_url
   type    = "A"
   zone_id = var.hosted_zone.id
+  allow_overwrite = var.overwrite_records
   alias {
     evaluate_target_health = true
     name                   = aws_alb.alb.dns_name
@@ -267,6 +268,7 @@ resource "aws_route53_record" "aaaa_record" {
   name    = local.app_domain_url
   type    = "AAAA"
   zone_id = var.hosted_zone.id
+  allow_overwrite = var.overwrite_records
   alias {
     evaluate_target_health = true
     name                   = aws_alb.alb.dns_name

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,11 @@ variable "site_url" {
   description = "The URL for the site."
   default     = null
 }
+variable "overwrite_records" {
+  type        = bool
+  description = "Allow creation of Route53 records in Terraform to overwrite an existing record, if any."
+  default     = false
+}
 variable "hosted_zone" {
   type = object({
     name = string,


### PR DESCRIPTION
This allows users to overwrite existing route53 records that already exist. It's especially useful for handel to terraform migrations. 