### PR TITLE
add list of cidrs and sg for the alb sg

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ module "my_app" {
 | vpc_id | string | VPC ID to deploy the ECS fargate service and ALB | |
 | public_subnet_ids | list(string) | List of subnet IDs for the ALB | |
 | alb_internal_flag | bool | Marks an ALB as Internal (Inaccessible to public internet) | false
+| alb_sg_ingress_cidrs | list(string) | List of cidrs to allow alb ingress for | ["0.0.0.0/0"]
+| alb_sg_ingress_sg_ids | llist(string) | List of security groups to allow ingress | []
 | private_subnet_ids | list(string) | List of subnet IDs for the fargate service | |
 | codedeploy_service_role_arn | string | ARN of the IAM Role for the CodeDeploy to use to initiate new deployments. (usually the PowerBuilder Role) | |
 | codedeploy_termination_wait_time | number | the number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment | 15 |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ customized solution you may need to use this code more as a pattern or guideline
 ## Usage
 ```hcl
 module "my_app" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.1"
   app_name       = "example-api"
   container_port = 8000
   primary_container_definition = {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -14,7 +14,7 @@ data "aws_elb_service_account" "main" {}
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.1"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -11,7 +11,7 @@ module "acs" {
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.1"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/main.tf
+++ b/main.tf
@@ -148,25 +148,28 @@ resource "aws_security_group" "alb-sg" {
 
   // allow access to the ALB from anywhere for 80 and 443
   ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    cidr_blocks     = var.alb_sg_ingress_cidrs
+    security_groups = var.alb_sg_ingress_sg_ids
   }
   ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    cidr_blocks     = var.alb_sg_ingress_cidrs
+    security_groups = var.alb_sg_ingress_sg_ids
   }
   // if test listener port is specified, allow traffic
   dynamic "ingress" {
     for_each = var.codedeploy_test_listener_port != null ? [1] : []
     content {
-      from_port   = var.codedeploy_test_listener_port
-      to_port     = var.codedeploy_test_listener_port
-      protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
+      from_port       = var.codedeploy_test_listener_port
+      to_port         = var.codedeploy_test_listener_port
+      protocol        = "tcp"
+      cidr_blocks     = var.alb_sg_ingress_cidrs
+      security_groups = var.alb_sg_ingress_sg_ids
     }
   }
   // allow any outgoing traffic

--- a/variables.tf
+++ b/variables.tf
@@ -113,10 +113,23 @@ variable "alb_internal_flag" {
   description = "Is the ALB Internal"
 }
 
+variable "alb_sg_ingress_cidrs" {
+  type        = list(string)
+  description = "List of cidrs to allow alb ingress for"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "alb_sg_ingress_sg_ids" {
+  type        = list(string)
+  description = "List of security groups to allow ingress"
+  default     = []
+}
+
 variable "private_subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs for the fargate service."
 }
+
 variable "codedeploy_service_role_arn" {
   type        = string
   description = "ARN of the IAM Role for the CodeDeploy to use to initiate new deployments. (usually the PowerBuilder Role)"


### PR DESCRIPTION
This adds the ability to optionally specify custom cidrs and security groups for the ALB.
Copied from https://github.com/byu-oit/terraform-aws-fargate-api/pull/28 so that `terraform plan` can run.

- add list of cidrs and sg for the alb sg
- update version numbers
