### PR TITLE
remove public IP from task ENIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ customized solution you may need to use this code more as a pattern or guideline
 ## Usage
 ```hcl
 module "my_app" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.2"
   app_name       = "example-api"
   container_port = 8000
   primary_container_definition = {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -14,7 +14,7 @@ data "aws_elb_service_account" "main" {}
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.2"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -11,7 +11,7 @@ module "acs" {
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v3.3.2"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/main.tf
+++ b/main.tf
@@ -452,7 +452,6 @@ resource "aws_ecs_service" "service" {
   network_configuration {
     subnets          = var.private_subnet_ids
     security_groups  = concat([aws_security_group.fargate_service_sg.id], var.security_groups)
-    assign_public_ip = true
   }
 
   load_balancer {

--- a/main.tf
+++ b/main.tf
@@ -638,7 +638,7 @@ resource "local_file" "appspec_json" {
           PlatformVersion = var.fargate_platform_version
           NetworkConfiguration = {
             AwsvpcConfiguration = {
-              Subnets = var.private_subnet_ids
+              Subnets        = var.private_subnet_ids
               SecurityGroups = concat([aws_security_group.fargate_service_sg.id], var.security_groups)
               AssignPublicIp = "DISABLED"
             }

--- a/main.tf
+++ b/main.tf
@@ -450,8 +450,8 @@ resource "aws_ecs_service" "service" {
     type = "CODE_DEPLOY"
   }
   network_configuration {
-    subnets          = var.private_subnet_ids
-    security_groups  = concat([aws_security_group.fargate_service_sg.id], var.security_groups)
+    subnets         = var.private_subnet_ids
+    security_groups = concat([aws_security_group.fargate_service_sg.id], var.security_groups)
   }
 
   load_balancer {

--- a/main.tf
+++ b/main.tf
@@ -636,6 +636,13 @@ resource "local_file" "appspec_json" {
             ContainerPort = var.container_port
           }
           PlatformVersion = var.fargate_platform_version
+          NetworkConfiguration = {
+            AwsvpcConfiguration = {
+              Subnets = var.private_subnet_ids
+              SecurityGroups = concat([aws_security_group.fargate_service_sg.id], var.security_groups)
+              AssignPublicIp = "DISABLED"
+            }
+          }
         }
       }
     }],

--- a/main.tf
+++ b/main.tf
@@ -466,9 +466,10 @@ resource "aws_ecs_service" "service" {
 
   lifecycle {
     ignore_changes = [
-      task_definition, // ignore because new revisions will get added after code deploy's blue-green deployment
-      load_balancer,   // ignore because load balancer can change after code deploy's blue-green deployment
-      desired_count    // igrnore because we're assuming you have autoscaling to manage the container count
+      task_definition,      // ignore because new revisions will get added after code deploy's blue-green deployment
+      load_balancer,        // ignore because load balancer can change after code deploy's blue-green deployment
+      desired_count,        // ignore because we're assuming you have autoscaling to manage the container count
+      network_configuration // ignore because it has to be managed by codedeploy
     ]
   }
 }


### PR DESCRIPTION
Task ENIs don't need a public IP address. They are deployed in private subnets, and are accessed via and ALB in the public subnets. Assigning public IP addresses to the Task ENIs is messy and wasteful.
