### PR TITLE
fix: http listener not defined target group issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ customized solution you may need to use this code more as a pattern or guideline
 
 ```hcl
 module "my_app" {
-  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v4.0.0"
+  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v4.0.1"
   app_name                     = "example-api"
   container_port               = 8000
   primary_container_definition = {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -14,7 +14,7 @@ data "aws_elb_service_account" "main" {}
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v4.0.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v4.0.1"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -11,7 +11,7 @@ module "acs" {
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v4.0.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v4.0.1"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/main.tf
+++ b/main.tf
@@ -248,10 +248,6 @@ resource "aws_alb_listener" "https" {
   default_action {
     type = "forward"
     forward {
-      stickiness {
-        duration = 0
-        enabled  = false
-      }
       target_group {
         arn    = aws_alb_target_group.blue.arn
         weight = 100
@@ -296,10 +292,6 @@ resource "aws_alb_listener" "test_listener" {
   default_action {
     type = "forward"
     forward {
-      stickiness {
-        duration = 0
-        enabled  = false
-      }
       target_group {
         arn    = aws_alb_target_group.blue.arn
         weight = 100

--- a/main.tf
+++ b/main.tf
@@ -266,8 +266,8 @@ resource "aws_alb_listener" "https" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      default_action[0].forward.target_group[0].weight,
-      default_action[0].forward.target_group[1].weight
+      default_action[0].forward[0].target_group[0].weight,
+      default_action[0].forward[0].target_group[1].weight
     ]
   }
   depends_on = [
@@ -315,8 +315,8 @@ resource "aws_alb_listener" "test_listener" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      default_action[0].forward.target_group[0].weight,
-      default_action[0].forward.target_group[1].weight
+      default_action[0].forward[0].target_group[0].weight,
+      default_action[0].forward[0].target_group[1].weight
     ]
   }
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -266,8 +266,8 @@ resource "aws_alb_listener" "https" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      default_action[0].forward[0].target_group[0].weight,
-      default_action[0].forward[0].target_group[1].weight
+      tolist(default_action[0].forward[0].target_group)[0].weight,
+      tolist(default_action[0].forward[0].target_group)[1].weight
     ]
   }
   depends_on = [
@@ -315,8 +315,8 @@ resource "aws_alb_listener" "test_listener" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      default_action[0].forward[0].target_group[0].weight,
-      default_action[0].forward[0].target_group[1].weight
+      tolist(default_action[0].forward[0].target_group)[0].weight,
+      tolist(default_action[0].forward[0].target_group)[1].weight
     ]
   }
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -246,11 +246,29 @@ resource "aws_alb_listener" "https" {
   protocol          = "HTTPS"
   certificate_arn   = var.https_certificate_arn
   default_action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.blue.arn
+    type = "forward"
+    forward {
+      stickiness {
+        duration = 0
+        enabled  = false
+      }
+      target_group {
+        arn    = aws_alb_target_group.blue.arn
+        weight = 100
+      }
+      target_group {
+        arn    = aws_alb_target_group.green.arn
+        weight = 0
+      }
+    }
   }
   lifecycle {
-    ignore_changes = [default_action[0].target_group_arn]
+    // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
+    ignore_changes = [
+      default_action[0].target_group_arn,
+      default_action[0].forward.target_group[0].weight,
+      default_action[0].forward.target_group[1].weight
+    ]
   }
   depends_on = [
     aws_alb_target_group.blue,
@@ -277,11 +295,29 @@ resource "aws_alb_listener" "test_listener" {
   protocol          = "HTTPS"
   certificate_arn   = var.https_certificate_arn
   default_action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.blue.arn
+    type = "forward"
+    forward {
+      stickiness {
+        duration = 0
+        enabled  = false
+      }
+      target_group {
+        arn    = aws_alb_target_group.blue.arn
+        weight = 100
+      }
+      target_group {
+        arn    = aws_alb_target_group.green.arn
+        weight = 0
+      }
+    }
   }
   lifecycle {
-    ignore_changes = [default_action[0].target_group_arn]
+    // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
+    ignore_changes = [
+      default_action[0].target_group_arn,
+      default_action[0].forward.target_group[0].weight,
+      default_action[0].forward.target_group[1].weight
+    ]
   }
   depends_on = [
     aws_alb_target_group.blue,

--- a/main.tf
+++ b/main.tf
@@ -266,8 +266,7 @@ resource "aws_alb_listener" "https" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      tolist(default_action[0].forward[0].target_group)[0].weight,
-      tolist(default_action[0].forward[0].target_group)[1].weight
+      default_action[0].forward[0].target_group
     ]
   }
   depends_on = [
@@ -315,8 +314,7 @@ resource "aws_alb_listener" "test_listener" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      tolist(default_action[0].forward[0].target_group)[0].weight,
-      tolist(default_action[0].forward[0].target_group)[1].weight
+      default_action[0].forward[0].target_group
     ]
   }
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,7 @@ resource "aws_alb_listener" "https" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      default_action[0].forward[0].target_group
+      default_action[0].forward[0].target_group[*].weight
     ]
   }
   depends_on = [
@@ -314,7 +314,7 @@ resource "aws_alb_listener" "test_listener" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      default_action[0].forward[0].target_group
+      default_action[0].forward[0].target_group[*].weight
     ]
   }
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,7 @@ resource "aws_alb_listener" "https" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      default_action[0].forward[0].target_group[*].weight
+      default_action[0].forward[0].target_group
     ]
   }
   depends_on = [
@@ -314,7 +314,7 @@ resource "aws_alb_listener" "test_listener" {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
       default_action[0].target_group_arn,
-      default_action[0].forward[0].target_group[*].weight
+      default_action[0].forward[0].target_group
     ]
   }
   depends_on = [


### PR DESCRIPTION
This _should_ fix the issue of terraform failing when trying to deploy https listener:
```
modifying ELBv2 Listener (arn:aws:elasticloadbalancing:us-west-2:***:listener/...): ValidationError: A target group ARN must be specified
```
