### PR TITLE
Set `desync_mitigation_mode` to `strictest` in ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ customized solution you may need to use this code more as a pattern or guideline
 
 ```hcl
 module "my_app" {
-  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v5.0.1"
+  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v5.0.2"
   app_name                     = "example-api"
   container_port               = 8000
   primary_container_definition = {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -24,7 +24,7 @@ data "aws_elb_service_account" "main" {}
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v5.0.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v5.0.2"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -21,7 +21,7 @@ module "acs" {
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v5.0.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v5.0.2"
   // source   = "../../" // for local testing
   app_name = "example-api"
   //  ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/main.tf
+++ b/main.tf
@@ -138,11 +138,12 @@ locals {
 
 # ==================== ALB ====================
 resource "aws_alb" "alb" {
-  name            = local.alb_name
-  subnets         = var.public_subnet_ids
-  security_groups = [aws_security_group.alb-sg.id]
-  tags            = var.tags
-  internal        = var.alb_internal_flag
+  name                   = local.alb_name
+  desync_mitigation_mode = "strictest"
+  subnets                = var.public_subnet_ids
+  security_groups        = [aws_security_group.alb-sg.id]
+  tags                   = var.tags
+  internal               = var.alb_internal_flag
 
   access_logs {
     bucket  = var.lb_logging_bucket_name


### PR DESCRIPTION
[`desync_mitigation_mode`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#desync_mitigation_mode) was added in [AWS provider v3.67.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.67.0). We [already require v3.69.0](https://github.com/byu-oit/terraform-aws-fargate-api/blob/ac7470597a1df8c9f3d9c1cabbb4a3beac7d2aaa/main.tf#L4).