### PR TITLE
Use only one target group for the listeners to fix sticky sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ customized solution you may need to use this code more as a pattern or guideline
 
 ```hcl
 module "my_app" {
-  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.0.0"
+  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.0.1"
   app_name                     = "example-api"
   container_port               = 8000
   primary_container_definition = {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -24,7 +24,7 @@ data "aws_elb_service_account" "main" {}
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.0.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.0.1"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/main.tf
+++ b/main.tf
@@ -253,10 +253,6 @@ resource "aws_alb_listener" "https" {
         arn    = aws_alb_target_group.blue.arn
         weight = 100
       }
-      target_group {
-        arn    = aws_alb_target_group.green.arn
-        weight = 0
-      }
     }
   }
   lifecycle {
@@ -296,10 +292,6 @@ resource "aws_alb_listener" "test_listener" {
       target_group {
         arn    = aws_alb_target_group.blue.arn
         weight = 100
-      }
-      target_group {
-        arn    = aws_alb_target_group.green.arn
-        weight = 0
       }
     }
   }


### PR DESCRIPTION
From https://docs.aws.amazon.com/elasticloadbalancing/latest/application/sticky-sessions.html: 
"If you have a [forward action](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#forward-actions) with **multiple** target groups, and sticky sessions are enabled for one or more of the target groups, you must enable stickiness at the target group level."

When we added a second target group to the listeners it broke because it would require their to get stickiness to the target group set on the listener. I considered setting the group sticky session, but that would mess up blue green deployments because traffic would stick to the target groups which doesn't make sense with blue green deployments.