### PR TITLE
Back off desync_mitigation_mode to defensive

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ customized solution you may need to use this code more as a pattern or guideline
 
 ```hcl
 module "my_app" {
-  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.1.0"
+  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.1.1"
   app_name                     = "example-api"
   container_port               = 8000
   primary_container_definition = {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -24,7 +24,7 @@ data "aws_elb_service_account" "main" {}
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.1.0"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.1.1"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ locals {
 # ==================== ALB ====================
 resource "aws_alb" "alb" {
   name                   = local.alb_name
-  desync_mitigation_mode = "strictest"
+  desync_mitigation_mode = "defensive"
   subnets                = var.public_subnet_ids
   security_groups        = [aws_security_group.alb-sg.id]
   tags                   = var.tags


### PR DESCRIPTION
Setting desync_mitigation_mode to strictest breaks clients that
aren't strictly RFC 7230 compliant (notably, AWS API Gateway).
Setting this attribute to defensive provides sufficent protection
against desync attacks, while still allowing requests from clients
that we can't perfect.
https://en.wikipedia.org/wiki/Robustness_principle
