### PR TITLE
New blue green deployment pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: '1.6.x'
+          terraform_version: '1.3.x'
 
       - name: Terraform Format
         working-directory: "./"
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform: [ '1.6.x' ]
+        terraform: [ '1.3.x' ]
       fail-fast: false
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: '1.3.x'
+          terraform_version: '1.6.x'
 
       - name: Terraform Format
         working-directory: "./"
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform: [ '1.3.x' ]
+        terraform: [ '1.6.x' ]
       fail-fast: false
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Terraform module pattern to build a standard Fargate API.
 
-This module creates a Fargate service with an ALB, AutoScaling, CodeDeploy configuration and a DNS record in front.
+This module creates a Fargate service with an ALB, AutoScaling, and a DNS record in front.
 
 **Note:** This module has many preset standards to make creating an API using Fargate easy. If you require a more
 customized solution you may need to use this code more as a pattern or guideline in how to build the resources you need.
@@ -13,13 +13,13 @@ customized solution you may need to use this code more as a pattern or guideline
 
 ```hcl
 module "my_app" {
-  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.3.1"
+  source                       = "github.com/byu-oit/terraform-aws-fargate-api?ref=v7.0.0"
   app_name                     = "example-api"
-  container_port               = 8000
+  container_port               = 80
   primary_container_definition = {
     name                  = "example"
-    image                 = "crccheck/hello-world"
-    ports                 = [8000]
+    image                 = "ngnix"
+    ports                 = [80]
     environment_variables = null
     secrets               = null
     efs_volume_mounts     = null
@@ -27,21 +27,13 @@ module "my_app" {
   }
 
   autoscaling_config            = null
-  codedeploy_test_listener_port = 8443
-  codedeploy_lifecycle_hooks    = {
-    BeforeInstall         = null
-    AfterInstall          = null
-    AfterAllowTestTraffic = "testLifecycle"
-    BeforeAllowTraffic    = null
-    AfterAllowTraffic     = null
-  }
+  test_listener_port = 8443
 
   hosted_zone                   = module.acs.route53_zone
   https_certificate_arn         = module.acs.certificate.arn
   public_subnet_ids             = module.acs.public_subnet_ids
   private_subnet_ids            = module.acs.private_subnet_ids
   vpc_id                        = module.acs.vpc.id
-  codedeploy_service_role_arn   = module.acs.power_builder_role.arn
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
 
   tags = {
@@ -66,9 +58,6 @@ module "my_app" {
 * ALB
     * with security group
 * 2 Target Groups (for blue-green deployment)
-* CodeDeploy App
-    * with IAM role
-* CodeDeploy Group
 * DNS A-Record
 * HTTPS Certificate (if not provided)
   * with DNS validation record
@@ -108,18 +97,15 @@ module "my_app" {
 | alb_sg_ingress_sg_ids             | list(string)                                | List of security groups to allow ingress                                                                                                                                                                                                                                                                                                                                                             | []                                                                                     |
 | alb_idle_timeout                  | number                                      | The time in seconds that the connection is allowed to be idle. Defaults to 60 seconds.                                                                                                                                                                                                                                                                                                               |
 | private_subnet_ids                | list(string)                                | List of subnet IDs for the fargate service                                                                                                                                                                                                                                                                                                                                                           |                                                                                        |
-| codedeploy_service_role_arn       | string                                      | ARN of the IAM Role for the CodeDeploy to use to initiate new deployments. (usually the PowerBuilder Role)                                                                                                                                                                                                                                                                                           |                                                                                        |
-| codedeploy_termination_wait_time  | number                                      | the number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment                                                                                                                                                                                                                                                                    | 15                                                                                     |
-| codedeploy_test_listener_port     | number                                      | The port for a codedeploy test listener. If provided CodeDeploy will use this port for test traffic on the new replacement set during the blue-green deployment process before shifting production traffic to the replacement set                                                                                                                                                                    | `null`                                                                                 |
-| codedeploy_lifecycle_hooks        | [object](#codedeploy_lifecycle_hooks)       | Define Lambda Functions for each CodeDeploy [lifecycle event hooks](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html). Use the Lambda function names as the values. Omit or set specific hooks to `null` if you don't want to invoke a lambda function at that hook. Omit or set this variable to `null` to not have any lifecycle hooks invoked. | `null`                                                                                 |
-| appspec_filename                  | string                                      | Filename (including path) to use when outputing appspec json.                                                                                                                                                                                                                                                                                                                                        | `appspec.json` in the current working directory (i.e. where you ran `terraform apply`) |
+| termination_wait_time             | number                                      | the number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment                                                                                                                                                                                                                                                                    | 15                                                                                     |
+| test_listener_port                | number                                      | The port for a codedeploy test listener. If provided ECS will use this port for test traffic on the new replacement set during the blue-green deployment process before shifting production traffic to the replacement set                                                                                                                                                                           | `null`                                                                                 |
 | role_permissions_boundary_arn     | string                                      | ARN of the IAM Role permissions boundary to place on each IAM role created                                                                                                                                                                                                                                                                                                                           |                                                                                        |
 | target_group_deregistration_delay | number                                      | Deregistration delay in seconds for ALB target groups                                                                                                                                                                                                                                                                                                                                                | 60                                                                                     |
 | target_group_sticky_sessions      | boolean                                     | Enables sticky sessions on the ALB target groups                                                                                                                                                                                                                                                                                                                                                     | false                                                                                  |
 | site_url                          | string                                      | The URL for the site.                                                                                                                                                                                                                                                                                                                                                                                | Concatenates app_name with hosted_zone_name.                                           |
 | overwrite_records                 | bool                                        | Allow creation of Route53 records in Terraform to overwrite an existing record, if any.                                                                                                                                                                                                                                                                                                              | false                                                                                  |
 | hosted_zone                       | [object](#hosted_zone)                      | Hosted Zone object to redirect to ALB. (Can pass in the aws_hosted_zone object). A and AAAA records created in this hosted zone                                                                                                                                                                                                                                                                      |                                                                                        |
-| https_certificate_arn             | string                                      | ARN of the HTTPS certificate of the hosted zone/domain. Defaults to creating its own certificate.                                                                                                                                                                                                                                                                                                    | `null`                                                                                  |
+| https_certificate_arn             | string                                      | ARN of the HTTPS certificate of the hosted zone/domain. Defaults to creating its own certificate.                                                                                                                                                                                                                                                                                                    | `null`                                                                                 |
 | autoscaling_config                | [object](#autoscaling_config)               | Configuration for default autoscaling policies and alarms. Additional advanced scaling options, which are optional, can be made with the "scaling_up_policy_config", "scaling_up_metric_alarm_config", "scaling_down_policy_config", and "scaling_down_metric_alarm_config" variables. Omit or set to `null` if you want to set up your own autoscaling policies and alarms.                         | `null`                                                                                 |
 | scaling_up_policy_config          | [object](#scaling_up_policy_config)         | Optional advanced configuration for the scaling up policy if 'autoscaling_config' is in use.                                                                                                                                                                                                                                                                                                         | See object definition [object](#scaling_up_policy_config)                              |                                                                        
 | scaling_up_metric_alarm_config    | [object](#scaling_up_metric_alarm_config)   | Optional advanced configuration for the scaling up metric alarm if 'autoscaling_config' is in use.                                                                                                                                                                                                                                                                                                   | See object definition [object](#scaling_up_metric_alarm_config)                        |                                                                        
@@ -141,7 +127,7 @@ Object with following attributes to define an existing ECS cluster to deploy the
 If you want to deploy this scheduled fargate task onto an existing cluster you would need to define this variable. For example:
 ```hcl
 module "test_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.3.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v7.0.0"
   app_name             = "example-api"
   existing_ecs_cluster = {
     arn  = aws_ecs_cluster.my_cluster.arn
@@ -214,21 +200,6 @@ See the following docs for more details:
 
 * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html
 * https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html
-
-#### codedeploy_lifecycle_hooks
-
-This variable is used when generating the [appspec.json](#appspec) file. This will define what Lambda Functions to
-invoke at
-specific [lifecycle hooks](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html)
-. Omit this variable or set it to `null` if you don't want to invoke any lambda functions. Omit or set a hook to `null` if you don't
-need that specific lifecycle hook function.
-
-* **`before_install`** - lambda function name to run before new task set is created
-* **`after_install`** - lambda function name to run after new task set is created before test traffic points to new task
-  set
-* **`after_allow_test_traffic`** - lambda function name to run after test traffic points to new task set
-* **`before_allow_traffic`** - lambda function name to run before public traffic points to new task set
-* **`after_allow_traffic`** - lambda function name to run after public traffic points to new task set
 
 #### hosted_zone
 
@@ -363,8 +334,6 @@ with the container logs in `example-api/example/12d344fd34b556ae4326...`
 | new_ecs_cluster                | [object](https://www.terraform.io/docs/providers/aws/r/ecs_cluster.html#attributes-reference)                       | Newly created ECS Cluster the service is deployed on, if var.existing_ecs_cluster is provided this will return null |
 | fargate_service_security_group | [object](https://www.terraform.io/docs/providers/aws/r/security_group.html#attributes-reference)                    | Security Group object assigned to the Fargate service                                                               |
 | task_definition                | [object](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#attributes-reference)               | The task definition object of the fargate service                                                                   |
-| codedeploy_deployment_group    | [object](https://www.terraform.io/docs/providers/aws/r/codedeploy_deployment_group.html#attributes-reference)       | The CodeDeploy deployment group object.                                                                             |
-| codedeploy_appspec_json_file   | string                                                                                                              | Filename of the generated appspec.json file                                                                         |
 | alb                            | [object](https://www.terraform.io/docs/providers/aws/r/lb.html#attributes-reference)                                | The Application Load Balancer (ALB) object                                                                          |
 | alb_target_group_blue          | [object](https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#attributes-reference)                   | The Application Load Balancer Target Group (ALB Target Group) object for the blue deployment                        |
 | alb_target_group_green         | [object](https://www.terraform.io/docs/providers/aws/r/lb_target_group.html#attributes-reference)                   | The Application Load Balancer Target Group (ALB Target Group) object  for the green deployment                      |
@@ -376,98 +345,15 @@ with the container logs in `example-api/example/12d344fd34b556ae4326...`
 | task_role                      | [object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#attributes-reference) | IAM role created for the tasks.                                                                                     |
 | task_execution_role            | [object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#attributes-reference) | IAM role created for the execution of tasks.                                                                        |
 
-#### appspec
+## Blue-Green Deployment
 
-This module also creates a JSON file in the project directory: `appspec.json` used to initiate a CodeDeploy Deployment.
-
-Here's an example appspec.json file this creates:
-
-```json
-{
-  "Resources": [
-    {
-      "TargetService": {
-        "Properties": {
-          "LoadBalancerInfo": {
-            "ContainerName": "example",
-            "ContainerPort": 8000
-          },
-          "TaskDefinition": "arn:aws:ecs:us-west-2:123456789123:task-definition/example-api-def:2"
-        },
-        "Type": "AWS::ECS::SERVICE"
-      }
-    }
-  ],
-  "version": 1
-}
-```
-
-And example with [lifecycle hooks](#codedeploy_lifecycle_hooks):
-
-```json
-{
-  "Hooks": [
-    {
-      "BeforeInstall": null
-    },
-    {
-      "AfterInstall": "AfterInstallHookFunctionName"
-    },
-    {
-      "AfterAllowTestTraffic": "AfterAllowTestTrafficHookFunctionName"
-    },
-    {
-      "BeforeAllowTraffic": null
-    },
-    {
-      "AfterAllowTraffic": null
-    }
-  ],
-  "Resources": [
-    {
-      "TargetService": {
-        "Properties": {
-          "LoadBalancerInfo": {
-            "ContainerName": "example",
-            "ContainerPort": 8000
-          },
-          "TaskDefinition": "arn:aws:ecs:us-west-2:123456789123:task-definition/example-api-def:2"
-        },
-        "Type": "AWS::ECS::SERVICE"
-      }
-    }
-  ],
-  "version": 1
-}
-```
-
-## CodeDeploy Blue-Green Deployment
-
-This module creates a blue-green deployment process with CodeDeploy. If a `codedeploy_test_listener_port` is provided
+This module uses the blue-green deployment process with ECS. If a `test_listener_port` is provided
 this module will create an ALB listener that will allow public traffic from that port to the running fargate service.
 
-When a CodeDeploy deployment is initiated (either via a pipeline or manually) CodeDeploy will:
-
-1. call lambda function defined for `BeforeInstall` hook
-2. attempt to create a new set of tasks (called the replacement set) with the new task definition etc. in the unused ALB
-   Target Group
-3. call lambda function defined for `AfterInstall` hook
-4. associate the test listener (if defined) to the new target group
-5. call lambda function defined for `AfterAllowTestTraffic` hook
-6. call lambda function defined for `BeforeAllowTraffic` hook
-7. associate the production listener to the new target group
-8. call lambda function defined for `AfterAllowTraffic` hook
-9. wait for the `codedeploy_termination_wait_time` in minutes before destroying the original task set (this is useful if
-   you need to manually rollback)
-
-At any step (except step #1) the deployment can rollback (either manually or by the lambda functions in the lifecycle
-hooks or if there was an error trying to actually deploy)
+When a deployment is initiated (either via a pipeline or manually) ECS BlueGreen will:
 
 ##### TODO add diagrams to explain the blue-green deployment process
 
 ## Note
 
-If you require additional variables please create
-an [issue](https://github.com/byu-oit/terraform-aws-fargate-api/issues)
-and/or a [pull request](https://github.com/byu-oit/terraform-aws-fargate-api/pulls) to add the variable and reach out to
-the Terraform Working Group on slack (`#terraform` channel).
+If you require additional variables please create an [issue](https://github.com/byu-oit/terraform-aws-fargate-api/issues) and/or a [pull request](https://github.com/byu-oit/terraform-aws-fargate-api/pulls) to add the variable and reach out in the CES AWS channel.

--- a/examples/ci/.terraform.lock.hcl
+++ b/examples/ci/.terraform.lock.hcl
@@ -2,45 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.67.0"
-  constraints = ">= 4.0.0, ~> 4.0, >= 4.2.0"
+  version     = "6.28.0"
+  constraints = ">= 4.2.0, >= 6.0.0, ~> 6.0"
   hashes = [
-    "h1:LfOuBkdYCzQhtiRvVIxdP/KGJODa3cRsKjn8xKCTbVY=",
-    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
-    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
-    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
-    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
-    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
-    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
-    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
-    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
-    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
-    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "h1:wzZdGs0FFmNqIgPyo9tKnGKJ37BGNSgwRrEXayL29+0=",
+    "zh:0ba0d5eb6e0c6a933eb2befe3cdbf22b58fbc0337bf138f95bf0e8bb6e6df93e",
+    "zh:23eacdd4e6db32cf0ff2ce189461bdbb62e46513978d33c5de4decc4670870ec",
+    "zh:307b06a15fc00a8e6fd243abde2cbe5112e9d40371542665b91bec1018dd6e3c",
+    "zh:37a02d5b45a9d050b9642c9e2e268297254192280df72f6e46641daca52e40ec",
+    "zh:3da866639f07d92e734557d673092719c33ede80f4276c835bf7f231a669aa33",
+    "zh:480060b0ba310d0f6b6a14d60b276698cb103c48fd2f7e2802ae47c963995ec6",
+    "zh:57796453455c20db80d9168edbf125bf6180e1aae869de1546a2be58e4e405ec",
+    "zh:69139cba772d4df8de87598d8d8a2b1b4b254866db046c061dccc79edb14e6b9",
+    "zh:7312763259b859ff911c5452ca8bdf7d0be6231c5ea0de2df8f09d51770900ac",
+    "zh:8d2d6f4015d3c155d7eb53e36f019a729aefb46ebfe13f3a637327d3a1402ecc",
+    "zh:94ce589275c77308e6253f607de96919b840c2dd36c44aa798f693c9dd81af42",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
-    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
-    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
-    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
-    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/local" {
-  version = "2.4.0"
-  hashes = [
-    "h1:7RnIbO3CFakblTJs7o0mUiY44dc9xGYsLhSNFSNS1Ds=",
-    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
-    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
-    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
-    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
-    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
-    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
-    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
-    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
-    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
-    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
-    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+    "zh:adaceec6a1bf4f5df1e12bd72cf52b72087c72efed078aef636f8988325b1a8b",
+    "zh:d37be1ce187d94fd9df7b13a717c219964cd835c946243f096c6b230cdfd7e92",
+    "zh:fe6205b5ca2ff36e68395cb8d3ae10a3728f405cdbcd46b206a515e1ebcf17a1",
   ]
 }

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.6"
 
   required_providers {
     aws = {

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -54,7 +54,7 @@ module "fargate_api" {
     ]
   }
 
-  autoscaling_config            = null
+  autoscaling_config = null
   test_listener_port = 8443
   codedeploy_lifecycle_hooks = {
     BeforeInstall         = null

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -55,7 +55,7 @@ module "fargate_api" {
   }
 
   autoscaling_config            = null
-  codedeploy_test_listener_port = 8443
+  test_listener_port = 8443
   codedeploy_lifecycle_hooks = {
     BeforeInstall         = null
     AfterInstall          = null

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -56,20 +56,12 @@ module "fargate_api" {
 
   autoscaling_config = null
   test_listener_port = 8443
-  codedeploy_lifecycle_hooks = {
-    BeforeInstall         = null
-    AfterInstall          = null
-    AfterAllowTestTraffic = "testLifecycle"
-    BeforeAllowTraffic    = null
-    AfterAllowTraffic     = null
-  }
 
   hosted_zone                   = module.acs.route53_zone
   https_certificate_arn         = module.acs.certificate.arn
   public_subnet_ids             = module.acs.public_subnet_ids
   private_subnet_ids            = module.acs.private_subnet_ids
   vpc_id                        = module.acs.vpc.id
-  codedeploy_service_role_arn   = module.acs.power_builder_role.arn
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
   xray_enabled                  = true
 
@@ -97,14 +89,6 @@ output "fargate_service_security_group" {
 
 output "task_definition" {
   value = module.fargate_api.task_definition.arn
-}
-
-output "codedeploy_deployment_group" {
-  value = module.fargate_api.codedeploy_deployment_group.id
-}
-
-output "codedeploy_appspec_json_file" {
-  value = module.fargate_api.codedeploy_appspec_json_file
 }
 
 output "alb" {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.6"
 
   required_providers {
     aws = {

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/logging/logging.tf
+++ b/examples/logging/logging.tf
@@ -24,7 +24,7 @@ data "aws_elb_service_account" "main" {}
 //  name = "fake-example-cluster"
 //}
 module "fargate_api" {
-  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v6.3.1"
+  source = "github.com/byu-oit/terraform-aws-fargate-api?ref=v7.0.0"
   //  source           = "../../" // for local testing
   app_name = "example-api"
   //ecs_cluster_name = aws_ecs_cluster.existing.name

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }
@@ -28,11 +28,11 @@ module "fargate_api" {
     id   = aws_ecs_cluster.existing.id
     name = aws_ecs_cluster.existing.name
   }
-  container_port = 8000
+  container_port = 80
   primary_container_definition = {
     name  = "example"
-    image = "crccheck/hello-world"
-    ports = [8000]
+    image = "nginx"
+    ports = [80]
     environment_variables = {
       env = "tst"
     }
@@ -41,17 +41,13 @@ module "fargate_api" {
     }
   }
 
-  codedeploy_test_listener_port = 8443
-  codedeploy_lifecycle_hooks = {
-    AfterAllowTestTraffic = "testLifecycle"
-  }
+  test_listener_port = 8443
 
   hosted_zone                   = module.acs.route53_zone
   https_certificate_arn         = module.acs.certificate.arn
   public_subnet_ids             = module.acs.public_subnet_ids
   private_subnet_ids            = module.acs.private_subnet_ids
   vpc_id                        = module.acs.vpc.id
-  codedeploy_service_role_arn   = module.acs.power_builder_role.arn
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
 
   tags = {
@@ -63,8 +59,4 @@ module "fargate_api" {
 
 output "url" {
   value = module.fargate_api.dns_record.fqdn
-}
-
-output "appspec_filename" {
-  value = module.fargate_api.codedeploy_appspec_json_file
 }

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -33,12 +33,6 @@ module "fargate_api" {
     name  = "example"
     image = "nginx"
     ports = [80]
-    environment_variables = {
-      env = "tst"
-    }
-    secrets = {
-      foo = "/super-secret"
-    }
   }
 
   test_listener_port = 8443
@@ -59,4 +53,12 @@ module "fargate_api" {
 
 output "url" {
   value = module.fargate_api.dns_record.fqdn
+}
+
+output "task_definition" {
+  value = "${module.fargate_api.task_definition.family}:${module.fargate_api.task_definition.revision}"
+}
+
+output "deploy_now_command" {
+  value = "aws ecs update-service --cluster ${aws_ecs_cluster.existing.name} --service ${module.fargate_api.fargate_service.name} --task-definition ${module.fargate_api.task_definition.family}:${module.fargate_api.task_definition.revision} --force-new-deployment"
 }

--- a/examples/simple/simple.tf
+++ b/examples/simple/simple.tf
@@ -35,7 +35,8 @@ module "fargate_api" {
     ports = [80]
   }
 
-  test_listener_port = 8443
+  test_listener_port    = 8443
+  termination_wait_time = 1
 
   hosted_zone                   = module.acs.route53_zone
   https_certificate_arn         = module.acs.certificate.arn

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 1.3.0"
   required_providers {
-    aws = ">= 4.0"
+    aws = ">= 6.0"
   }
 }
 
@@ -22,7 +22,7 @@ locals {
     values(def.secrets != null ? def.secrets : {})
   ]))
   has_secrets            = length(local.ssm_parameters) > 0
-  ssm_parameter_arn_base = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/"
+  ssm_parameter_arn_base = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/"
   secrets_arns = [
     for param in local.ssm_parameters :
     "${local.ssm_parameter_arn_base}${replace(param, "/^//", "")}"
@@ -54,7 +54,7 @@ locals {
         logDriver = "awslogs"
         options = {
           awslogs-group         = local.cloudwatch_log_group_name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = local.service_name
         }
       }
@@ -107,7 +107,7 @@ locals {
       logDriver = "awslogs"
       options = {
         awslogs-group         = local.xray_cloudwatch_log_group_name
-        awslogs-region        = data.aws_region.current.name
+        awslogs-region        = data.aws_region.current.region
         awslogs-stream-prefix = "${local.service_name}-xray"
       }
     }
@@ -118,27 +118,6 @@ locals {
     ulimits     = []
   }]
   container_definitions = var.xray_enabled == true ? concat(local.user_containers, local.xray_container) : local.user_containers
-
-  hooks = var.codedeploy_lifecycle_hooks != null ? setsubtract([
-    for hook in keys(var.codedeploy_lifecycle_hooks) :
-    zipmap([hook], [lookup(var.codedeploy_lifecycle_hooks, hook, null)])
-    ], [
-    {
-      BeforeInstall = null
-    },
-    {
-      AfterInstall = null
-    },
-    {
-      AfterAllowTestTraffic = null
-    },
-    {
-      BeforeAllowTraffic = null
-    },
-    {
-      AfterAllowTraffic = null
-    }
-  ]) : null
 }
 
 # ==================== ALB ====================
@@ -179,10 +158,10 @@ resource "aws_security_group" "alb-sg" {
   }
   // if test listener port is specified, allow traffic
   dynamic "ingress" {
-    for_each = var.codedeploy_test_listener_port != null ? [1] : []
+    for_each = var.test_listener_port != null ? [1] : []
     content {
-      from_port       = var.codedeploy_test_listener_port
-      to_port         = var.codedeploy_test_listener_port
+      from_port       = var.test_listener_port
+      to_port         = var.test_listener_port
       protocol        = "tcp"
       cidr_blocks     = var.alb_sg_ingress_cidrs
       security_groups = var.alb_sg_ingress_sg_ids
@@ -253,6 +232,30 @@ resource "aws_alb_listener" "https" {
   protocol          = "HTTPS"
   certificate_arn   = local.create_new_https_cert ? aws_acm_certificate_validation.new_cert[0].certificate_arn : var.https_certificate_arn # if cert is not provided use created one, else use existing cert
   default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      status_code  = "404"
+      content_type = "text/plain"
+      message_body = "No matching rule"
+    }
+  }
+  # lifecycle {
+  #   // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
+  #   ignore_changes = [
+  #     default_action[0].target_group_arn,
+  #     default_action[0].forward[0].target_group
+  #   ]
+  # }
+  depends_on = [
+    aws_alb_target_group.blue,
+    aws_alb_target_group.green
+  ]
+}
+resource "aws_alb_listener_rule" "https" {
+  listener_arn = aws_alb_listener.https.arn
+  priority = 1
+  action {
     type = "forward"
     forward {
       target_group {
@@ -261,17 +264,17 @@ resource "aws_alb_listener" "https" {
       }
     }
   }
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
   lifecycle {
     // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
     ignore_changes = [
-      default_action[0].target_group_arn,
-      default_action[0].forward[0].target_group
+      action[0].forward[0].target_group
     ]
   }
-  depends_on = [
-    aws_alb_target_group.blue,
-    aws_alb_target_group.green
-  ]
 }
 resource "aws_alb_listener" "http_to_https" {
   load_balancer_arn = aws_alb.alb.arn
@@ -287,18 +290,18 @@ resource "aws_alb_listener" "http_to_https" {
   }
 }
 resource "aws_alb_listener" "test_listener" {
-  count             = var.codedeploy_test_listener_port != null ? 1 : 0
+  count             = var.test_listener_port != null ? 1 : 0
   load_balancer_arn = aws_alb.alb.arn
-  port              = var.codedeploy_test_listener_port
+  port              = var.test_listener_port
   protocol          = "HTTPS"
   certificate_arn   = local.create_new_https_cert ? aws_acm_certificate_validation.new_cert[0].certificate_arn : var.https_certificate_arn # if cert is not provided use created one, else use existing cert
   default_action {
-    type = "forward"
-    forward {
-      target_group {
-        arn    = aws_alb_target_group.blue.arn
-        weight = 100
-      }
+    type = "fixed-response"
+
+    fixed_response {
+      status_code  = "404"
+      content_type = "text/plain"
+      message_body = "No matching rule"
     }
   }
   lifecycle {
@@ -312,6 +315,31 @@ resource "aws_alb_listener" "test_listener" {
     aws_alb_target_group.blue,
     aws_alb_target_group.green
   ]
+}
+resource "aws_alb_listener_rule" "test" {
+  count             = var.test_listener_port != null ? 1 : 0
+  listener_arn = aws_alb_listener.test_listener[0].arn
+  priority = 1
+  action {
+    type = "forward"
+    forward {
+      target_group {
+        arn    = aws_alb_target_group.green.arn
+        weight = 100
+      }
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/*"]
+    }
+  }
+  lifecycle {
+    // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
+    ignore_changes = [
+      action[0].forward[0].target_group
+    ]
+  }
 }
 
 # ==================== HTTPS cert ====================
@@ -476,6 +504,30 @@ resource "aws_ecs_task_definition" "task_def" {
     }
   }
 }
+# --- ecs to access alb role ---
+data "aws_iam_policy_document" "ecs_to_alb" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    principals {
+      identifiers = ["ecs.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+resource "aws_iam_role" "ecs_to_alb" {
+  name                 = "${var.app_name}-ecsToAlb"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_to_alb.json
+  permissions_boundary = var.role_permissions_boundary_arn
+  tags                 = var.tags
+}
+resource "aws_iam_role_policy_attachment" "ecs_to_alb" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonECSInfrastructureRolePolicyForLoadBalancers"
+  role       = aws_iam_role.ecs_to_alb.name
+}
 
 # ==================== Fargate ====================
 resource "aws_ecs_cluster" "new_cluster" {
@@ -510,9 +562,15 @@ resource "aws_ecs_service" "service" {
   launch_type      = "FARGATE"
   platform_version = var.fargate_platform_version
   propagate_tags   = "TASK_DEFINITION"
-  deployment_controller {
-    type = "CODE_DEPLOY"
+  deployment_configuration {
+    strategy = "BLUE_GREEN"
+    # type = "CODE_DEPLOY"
+    bake_time_in_minutes = "15"
   }
+  sigint_rollback = true
+  wait_for_steady_state = true
+  # force_new_deployment = true
+
   network_configuration {
     subnets         = var.private_subnet_ids
     security_groups = concat([aws_security_group.fargate_service_sg.id], var.security_groups)
@@ -522,6 +580,12 @@ resource "aws_ecs_service" "service" {
     target_group_arn = aws_alb_target_group.blue.arn
     container_name   = var.primary_container_definition.name
     container_port   = var.container_port
+    advanced_configuration {
+      alternate_target_group_arn = aws_alb_target_group.green.arn
+      production_listener_rule   = aws_alb_listener_rule.https.arn
+      test_listener_rule         = var.test_listener_port != null ? aws_alb_listener_rule.test[0].arn : null
+      role_arn                   = aws_iam_role.ecs_to_alb.arn
+    }
   }
 
   health_check_grace_period_seconds = var.health_check_grace_period
@@ -541,60 +605,6 @@ resource "aws_ecs_service" "service" {
     aws_alb_target_group.blue,
     aws_alb_target_group.green
   ]
-}
-
-# ==================== CodeDeploy ====================
-resource "aws_codedeploy_app" "app" {
-  name             = "${var.app_name}-codedeploy"
-  compute_platform = "ECS"
-}
-
-resource "aws_codedeploy_deployment_group" "deploymentgroup" {
-  app_name               = aws_codedeploy_app.app.name
-  deployment_group_name  = "${var.app_name}-deployment-group"
-  service_role_arn       = var.codedeploy_service_role_arn
-  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
-
-  ecs_service {
-    cluster_name = local.cluster_name
-    service_name = aws_ecs_service.service.name
-  }
-
-  blue_green_deployment_config {
-    deployment_ready_option {
-      action_on_timeout = "CONTINUE_DEPLOYMENT"
-    }
-    terminate_blue_instances_on_deployment_success {
-      action                           = "TERMINATE"
-      termination_wait_time_in_minutes = var.codedeploy_termination_wait_time
-    }
-  }
-
-  deployment_style {
-    deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type   = "BLUE_GREEN"
-  }
-  auto_rollback_configuration {
-    enabled = true
-    events  = ["DEPLOYMENT_FAILURE"]
-  }
-
-  load_balancer_info {
-    target_group_pair_info {
-      prod_traffic_route {
-        listener_arns = [aws_alb_listener.https.arn]
-      }
-      test_traffic_route {
-        listener_arns = var.codedeploy_test_listener_port != null ? [aws_alb_listener.test_listener[0].arn] : []
-      }
-      target_group {
-        name = aws_alb_target_group.blue.name
-      }
-      target_group {
-        name = aws_alb_target_group.green.name
-      }
-    }
-  }
 }
 
 # ==================== CloudWatch ====================
@@ -690,31 +700,3 @@ resource "aws_cloudwatch_metric_alarm" "down" {
   tags                = var.tags
 }
 
-# ==================== AppSpec file ====================
-resource "local_file" "appspec_json" {
-  filename = var.appspec_filename != null ? var.appspec_filename : "${path.cwd}/appspec.json"
-  content = jsonencode({
-    version = 1
-    Resources = [{
-      TargetService = {
-        Type = "AWS::ECS::SERVICE"
-        Properties = {
-          TaskDefinition = aws_ecs_task_definition.task_def.arn
-          LoadBalancerInfo = {
-            ContainerName = var.primary_container_definition.name
-            ContainerPort = var.container_port
-          }
-          PlatformVersion = var.fargate_platform_version
-          NetworkConfiguration = {
-            AwsvpcConfiguration = {
-              Subnets        = var.private_subnet_ids
-              SecurityGroups = concat([aws_security_group.fargate_service_sg.id], var.security_groups)
-              AssignPublicIp = "DISABLED"
-            }
-          }
-        }
-      }
-    }],
-    Hooks = local.hooks
-  })
-}

--- a/main.tf
+++ b/main.tf
@@ -240,13 +240,6 @@ resource "aws_alb_listener" "https" {
       message_body = "No matching rule"
     }
   }
-  # lifecycle {
-  #   // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
-  #   ignore_changes = [
-  #     default_action[0].target_group_arn,
-  #     default_action[0].forward[0].target_group
-  #   ]
-  # }
   depends_on = [
     aws_alb_target_group.blue,
     aws_alb_target_group.green
@@ -270,7 +263,7 @@ resource "aws_alb_listener_rule" "https" {
     }
   }
   lifecycle {
-    // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
+    // Blue/Green deployment will switch the target groups back and forth for the listener
     ignore_changes = [
       action[0].forward[0].target_group
     ]
@@ -305,7 +298,7 @@ resource "aws_alb_listener" "test_listener" {
     }
   }
   lifecycle {
-    // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
+    // Blue/green deployment will switch the target groups back and forth for the listener
     ignore_changes = [
       default_action[0].target_group_arn,
       default_action[0].forward[0].target_group
@@ -335,7 +328,7 @@ resource "aws_alb_listener_rule" "test" {
     }
   }
   lifecycle {
-    // CodeDeploy will switch the target groups back and forth for the listener, so ignore them and let CodeDeploy manage target groups
+    // Blue/green deployment will switch the target groups back and forth for the listener
     ignore_changes = [
       action[0].forward[0].target_group
     ]
@@ -564,8 +557,7 @@ resource "aws_ecs_service" "service" {
   propagate_tags   = "TASK_DEFINITION"
   deployment_configuration {
     strategy = "BLUE_GREEN"
-    # type = "CODE_DEPLOY"
-    bake_time_in_minutes = "15"
+    bake_time_in_minutes = var.termination_wait_time
   }
   sigint_rollback = true
   wait_for_steady_state = true
@@ -594,13 +586,13 @@ resource "aws_ecs_service" "service" {
 
   lifecycle {
     ignore_changes = [
-      task_definition,      // ignore because new revisions will get added after code deploy's blue-green deployment
-      load_balancer,        // ignore because load balancer can change after code deploy's blue-green deployment
+      task_definition,      // ignore because new revisions will get added after blue-green deployment
+      load_balancer,        // ignore because load balancer can change after blue-green deployment
       desired_count,        // ignore because we're assuming you have autoscaling to manage the container count
-      network_configuration // ignore because it has to be managed by codedeploy
+      network_configuration // ignore because it has to be managed by blue-green deployment
     ]
   }
-  // If the target groups get re-created, the service needs to be re-created or CodeDeploy will fail
+  // If the target groups get re-created, the service needs to be re-created or blue/green deployment will fail
   depends_on = [
     aws_alb_target_group.blue,
     aws_alb_target_group.green

--- a/main.tf
+++ b/main.tf
@@ -561,7 +561,6 @@ resource "aws_ecs_service" "service" {
   }
   sigint_rollback       = true
   wait_for_steady_state = true
-  # force_new_deployment = true
 
   network_configuration {
     subnets         = var.private_subnet_ids
@@ -586,6 +585,7 @@ resource "aws_ecs_service" "service" {
 
   lifecycle {
     ignore_changes = [
+      // If we want terraform to run the deployment we just need to remove the task_definition from this ignore_changes list
       task_definition,      // ignore because new revisions will get added after blue-green deployment
       load_balancer,        // ignore because load balancer can change after blue-green deployment
       desired_count,        // ignore because we're assuming you have autoscaling to manage the container count

--- a/main.tf
+++ b/main.tf
@@ -247,7 +247,7 @@ resource "aws_alb_listener" "https" {
 }
 resource "aws_alb_listener_rule" "https" {
   listener_arn = aws_alb_listener.https.arn
-  priority = 1
+  priority     = 1
   action {
     type = "forward"
     forward {
@@ -310,9 +310,9 @@ resource "aws_alb_listener" "test_listener" {
   ]
 }
 resource "aws_alb_listener_rule" "test" {
-  count             = var.test_listener_port != null ? 1 : 0
+  count        = var.test_listener_port != null ? 1 : 0
   listener_arn = aws_alb_listener.test_listener[0].arn
-  priority = 1
+  priority     = 1
   action {
     type = "forward"
     forward {
@@ -556,10 +556,10 @@ resource "aws_ecs_service" "service" {
   platform_version = var.fargate_platform_version
   propagate_tags   = "TASK_DEFINITION"
   deployment_configuration {
-    strategy = "BLUE_GREEN"
+    strategy             = "BLUE_GREEN"
     bake_time_in_minutes = var.termination_wait_time
   }
-  sigint_rollback = true
+  sigint_rollback       = true
   wait_for_steady_state = true
   # force_new_deployment = true
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,14 +14,6 @@ output "task_definition" {
   value = aws_ecs_task_definition.task_def
 }
 
-output "codedeploy_deployment_group" {
-  value = aws_codedeploy_deployment_group.deploymentgroup
-}
-
-output "codedeploy_appspec_json_file" {
-  value = local_file.appspec_json.filename
-}
-
 output "alb" {
   value = aws_alb.alb
 }

--- a/variables.tf
+++ b/variables.tf
@@ -155,6 +155,11 @@ variable "private_subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs for the fargate service."
 }
+variable "termination_wait_time" {
+  type        = number
+  description = "The number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment. Defaults to 15"
+  default     = 15
+}
 variable "test_listener_port" {
   type        = number
   description = "The port for the test listener. This port will be used for test traffic on the new replacement set during the blue-green deployment process before shifting production traffic to the replacement set. Defaults to null"

--- a/variables.tf
+++ b/variables.tf
@@ -155,35 +155,9 @@ variable "private_subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs for the fargate service."
 }
-
-variable "codedeploy_service_role_arn" {
-  type        = string
-  description = "ARN of the IAM Role for the CodeDeploy to use to initiate new deployments. (usually the PowerBuilder Role)"
-}
-variable "codedeploy_termination_wait_time" {
+variable "test_listener_port" {
   type        = number
-  description = "The number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment. Defaults to 15"
-  default     = 15
-}
-variable "codedeploy_test_listener_port" {
-  type        = number
-  description = "The port for a codedeploy test listener. If provided CodeDeploy will use this port for test traffic on the new replacement set during the blue-green deployment process before shifting production traffic to the replacement set. Defaults to null"
-  default     = null
-}
-variable "codedeploy_lifecycle_hooks" {
-  type = object({
-    BeforeInstall         = optional(string)
-    AfterInstall          = optional(string)
-    AfterAllowTestTraffic = optional(string)
-    BeforeAllowTraffic    = optional(string)
-    AfterAllowTraffic     = optional(string)
-  })
-  description = "Define Lambda Functions for CodeDeploy lifecycle event hooks. Or set this variable to null to not have any lifecycle hooks invoked. Defaults to null"
-  default     = null
-}
-variable "appspec_filename" {
-  type        = string
-  description = "`appspec.json` in the current working directory (i.e. where you ran `terraform apply`)"
+  description = "The port for the test listener. This port will be used for test traffic on the new replacement set during the blue-green deployment process before shifting production traffic to the replacement set. Defaults to null"
   default     = null
 }
 variable "role_permissions_boundary_arn" {


### PR DESCRIPTION
Here's a draft of an updated module that uses the ECS blue/green deployment pattern instead of CodeDeploy's
https://aws.amazon.com/blogs/aws/accelerate-safe-software-releases-with-new-built-in-blue-green-deployments-in-amazon-ecs/

I've tested it out a bit and it's nice. Still not sure about some things, like should we have terraform perform the blue/green deployment or should we just initiate the deployment with a `aws ecs update-service` CLI command to keep our pattern similar to the existing one? Also I haven't tried implementing the lifecycle hooks yet.

Also, I tested the blue/green deployments. They're not much different in terms of how long it takes to deploy. The rollback was also pretty quick (I timed my rollback and it took only 35 seconds).

This is nice to me because it removes all the code deploy resources. It also removes the appsec file creation, which has always felt a little odd.

The ECS deployment interface is nice too:
<img width="1883" height="865" alt="image" src="https://github.com/user-attachments/assets/f923c3d3-2085-4d2e-b4c7-fe8405782607" />
